### PR TITLE
Dialog service

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -807,7 +807,7 @@ Style/NumericLiterals:
                  Add underscores to large numeric literals to improve their
                  readability.
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#underscores-in-numerics'
-  Enabled: true
+  Enabled: false
 
 Style/OneLineConditional:
   Description: >-

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,15 +1,8 @@
 class MessagesController < ApplicationController
-  MESSAGES = [
-      'Hi! How are you!',
-      'I\'m hungry, have anything to eat?',
-      'My name is Flashy',
-      'What do you want to study today? :)',
-      'When is your big test!?'
-  ]
 
   def webhook
     if params['hub.mode'] == 'subscribe' &&
-         params['hub.verify_token'] == 'flashy_is_the_bomb' # Sorta unsafe
+         params['hub.verify_token'] == ENV['FACEBOOK_MESSENGER_VERIFY_TOKEN'] # Sorta unsafe
       render text: params['hub.challenge']
     else
       head :forbidden

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -2,7 +2,7 @@ class MessagesController < ApplicationController
 
   def webhook
     if params['hub.mode'] == 'subscribe' &&
-         params['hub.verify_token'] == ENV['FACEBOOK_MESSENGER_VERIFY_TOKEN'] # Sorta unsafe
+         params['hub.verify_token'] == ENV['FACEBOOK_MESSENGER_VERIFY_TOKEN']
       render text: params['hub.challenge']
     else
       head :forbidden

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,2 @@
+class User < ApplicationRecord
+end

--- a/app/services/messenger_service.rb
+++ b/app/services/messenger_service.rb
@@ -41,24 +41,29 @@ class MessengerService
     if @user.last_question.nil?
       @user.update_attribute(:last_question, 'ask name')
       send_message "What's your name, or what would you like me to call you? :)"
+      sleep 0.5
       send_message "I think that would be more polite than automatically getting it from your facebook account :P"
     else
       @user.update_attribute(:name, @input)
       send_message "Nice to meet you #{@user.name}! :D"
+      send_message "Type 'register', 'study', or 'quiz me'"
       clear_state
     end
   end
 
   def select_quiz
     send_message "You chose select quiz"
+    clear_state
   end
 
   def quiz_me
     send_message "You quiz me"
+    clear_state
   end
 
   def study
     send_message "You study"
+    clear_state
   end
 
   def send_message(message)

--- a/app/services/messenger_service.rb
+++ b/app/services/messenger_service.rb
@@ -2,11 +2,12 @@ class MessengerService
 
   def initialize(sender_id, input)
     @user = User.find_or_create_by(messenger_id: sender_id)
-    @input = input.downcase.strip
+    @input = input
   end
 
   def route_incoming
     return ask_name unless @user.name.present?
+    @input = @input.downcase.strip
     case @input
       when 'register'
         @user.update_attribute(:last_command, 'register')

--- a/app/services/messenger_service.rb
+++ b/app/services/messenger_service.rb
@@ -1,0 +1,78 @@
+class MessengerService
+
+  def initialize(sender_id, input)
+    @user = User.find_or_create_by(messenger_id: sender_id)
+    @input = input.downcase.strip
+  end
+
+  def route_incoming
+    return ask_name unless @user.name.present?
+    case @input
+      when 'register'
+        @user.update_attribute(:last_command, 'register')
+        return select_quiz
+      when 'quiz me'
+        @user.update_attribute(:last_command, 'quiz me')
+        return quiz_me
+      when 'study'
+        @user.update_attribute(:last_command, 'study')
+        return study
+      else
+        case @user.last_command
+          when 'register'
+            @user.update_attribute(:last_command, 'register')
+            return select_quiz
+          when 'quiz me'
+            @user.update_attribute(:last_command, 'quiz me')
+            return quiz_me
+          when 'study'
+            @user.update_attribute(:last_command, 'study')
+            return study
+          else
+            return send_message "Sorry I don't understand that. Type 'register', 'quiz me', or 'study'"
+        end
+    end
+  end
+
+  private
+
+  def ask_name
+    @user.update_attribute(:last_command, 'ask name')
+    if @user.last_question.nil?
+      @user.update_attribute(:last_question, 'ask name')
+      send_message "What's your name, or what would you like me to call you? :)"
+      send_message "I think that would be more polite than automatically getting it from your facebook account :P"
+    else
+      @user.update_attribute(:name, @input)
+      send_message "Nice to meet you #{@user.name}! :D"
+      clear_state
+    end
+  end
+
+  def select_quiz
+    send_message "You chose select quiz"
+  end
+
+  def quiz_me
+    send_message "You quiz me"
+  end
+
+  def study
+    send_message "You study"
+  end
+
+  def send_message(message)
+    data = {
+        recipient: {id: @user.messenger_id},
+        message: {text: message}
+    }.to_json
+    RestClient.post "https://graph.facebook.com/v2.6/me/messages?access_token=#{ENV['PAGE_ACCESS_TOKEN']}",
+                    data, content_type: :json
+  end
+
+  def clear_state
+    @user.update_attribute(:last_command, nil)
+    @user.update_attribute(:last_question, nil)
+  end
+
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,4 +20,25 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+  ask_name_question: >
+    What's your name, or what would you like me to call you? :)
+
+  ask_name_confirmation: >
+    I think that would be more polite than automatically
+    getting it from your facebook account :P
+
+  ask_name_nice_to_meet: >
+    Nice to meet you %{name}! :D
+
+  ask_name_getting_started: >
+    Type 'register', 'study', or 'quiz me'
+
+  select_quiz_text: "You chose select quiz"
+
+  quiz_me_text: "You chose quiz me"
+
+  study_text: "You chose study"
+
+  unknown_command: "Sorry I don't understand that. Type 'register', 'quiz me', or 'study'"
+
+

--- a/db/migrate/20160916135105_create_users.rb
+++ b/db/migrate/20160916135105_create_users.rb
@@ -1,0 +1,12 @@
+class CreateUsers < ActiveRecord::Migration[5.0]
+  def change
+    create_table :users do |t|
+      t.string :messenger_id
+      t.string :name
+      t.string :last_command
+      t.integer :last_question
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,6 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 0) do
+ActiveRecord::Schema.define(version: 20160916135105) do
+
+  create_table "users", force: :cascade do |t|
+    t.string   "messenger_id"
+    t.string   "name"
+    t.string   "last_command"
+    t.integer  "last_question"
+    t.datetime "created_at",    null: false
+    t.datetime "updated_at",    null: false
+  end
 
 end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,0 +1,13 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  messenger_id: MyString
+  name: MyString
+  last_command: MyString
+  last_question: 1
+
+two:
+  messenger_id: MyString
+  name: MyString
+  last_command: MyString
+  last_question: 1

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class UserTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Adds the basic structure to support conversational dialog with the Flashy Facebook Messenger bot.

There are two levels that this design supports:
1) Commands. A command like 'register' or 'quiz me' will always take priority over any other action. Users can be deep within, for example, a studying session, type 'register' and force Flashy to start talking with that dialog flow.

2) Routing to the last command. Any message that is not a top level command will be routed to the last command. The method responsible for that command can do what it wishes with that information. There is a `last_command` field on every user instance to support this. The `last_question` field on a user instance is there to support remember the last "sub-command" given within a top level command. Use the `clear_state` method to force the user to input a valid top level command again.

In addition to routing commands, this PR also sets up the structure for moving message strings into the locale files provided by Rails. This makes the code a lot cleaner and there are some examples to see how to connect it altogether.
