### PR TITLE
Add support for the 'select quiz' and 'study' command.

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-QUIZLET_CLIENT_ID=xgqKzBBrfx

--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+QUIZLET_CLIENT_ID=xgqKzBBrfx

--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -1,0 +1,4 @@
+class Card < ApplicationRecord
+  belongs_to :card_set
+
+end

--- a/app/models/card_set.rb
+++ b/app/models/card_set.rb
@@ -1,0 +1,4 @@
+class CardSet < ApplicationRecord
+  has_many :cards
+
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,2 +1,7 @@
 class User < ApplicationRecord
+  has_many :card_sets
+
+  def current_card_set
+    CardSet.find(current_card_set_id)
+  end
 end

--- a/app/services/messenger_service.rb
+++ b/app/services/messenger_service.rb
@@ -38,8 +38,16 @@ class MessengerService
   end
 
   def select_quiz
-    send_message :select_quiz_text
-    clear_state
+    if @user.last_question == 'give quizlet number'
+      card_set = QuizletService.find_card_set(@user, @input) # TODO handle failure case
+      @user.current_card_set_id = card_set.id
+      @user.save
+      clear_state
+      send_message :select_quiz_success, title: card_set.title
+    else
+      set_last_question 'give quizlet number'
+      send_message :select_quiz_give_me_quizlet_number
+    end
   end
 
   def quiz_me
@@ -70,5 +78,9 @@ class MessengerService
   def clear_state
     @user.update_attribute(:last_command, nil)
     @user.update_attribute(:last_question, nil)
+  end
+
+  def set_last_question(question)
+    @user.update_attribute(:last_question, question)
   end
 end

--- a/app/services/messenger_service.rb
+++ b/app/services/messenger_service.rb
@@ -47,7 +47,7 @@ class MessengerService
       send_message :select_quiz_success, title: card_set.title
       clear_state
     else
-      set_last_question 'give quizlet number'
+      save_last_question 'give quizlet number'
       send_message :select_quiz_give_me_quizlet_number
     end
   end
@@ -60,7 +60,7 @@ class MessengerService
 
     unless @user.last_question
       send_message :study_getting_started
-      return set_last_question '1'
+      return save_last_question '1'
     end
 
     current_card_id = @user.last_question.to_i
@@ -68,10 +68,10 @@ class MessengerService
 
     if current_card_id >= cards.count
       send_message :study_all_done, count: cards.count
-      set_last_question '1'
+      save_last_question '1'
     else
       card = cards.where(id: current_card_id).take
-      set_last_question (current_card_id + 1).to_s
+      save_last_question(current_card_id + 1)
       send_message :study_flash_card, term: card.term, definition: card.definition
     end
   end
@@ -101,7 +101,7 @@ class MessengerService
     @user.update_attribute(:last_question, nil)
   end
 
-  def set_last_question(question)
+  def save_last_question(question)
     @user.update_attribute(:last_question, question)
   end
 end

--- a/app/services/messenger_service.rb
+++ b/app/services/messenger_service.rb
@@ -17,7 +17,7 @@ class MessengerService
       @user.update_attribute(:last_command, command)
       self.send(COMMAND_TO_METHOD[command])
     elsif @user.last_command
-      self.send(@user.last_command)
+      self.send(COMMAND_TO_METHOD[@user.last_command])
     else
       unknown_command
     end

--- a/app/services/messenger_service.rb
+++ b/app/services/messenger_service.rb
@@ -93,7 +93,7 @@ class MessengerService
     }.to_json
     RestClient.post "https://graph.facebook.com/v2.6/me/messages?access_token=#{ENV['PAGE_ACCESS_TOKEN']}",
                     data, content_type: :json
-    sleep .7 # In the future use an async task runner.
+    sleep 0.7 # In the future use an async task runner.
   end
 
   def clear_state

--- a/app/services/messenger_service.rb
+++ b/app/services/messenger_service.rb
@@ -12,12 +12,11 @@ class MessengerService
 
   def route_incoming
     return ask_name unless @user.name.present?
-    command = @input.downcase.strip
-    if COMMAND_TO_METHOD.key?(command) || @user.last_command == command
+    command = @user.last_command || @input.downcase.strip
+    if COMMAND_TO_METHOD.key?(command)
       @user.update_attribute(:last_command, command)
       self.send(COMMAND_TO_METHOD[command])
     else
-      clear_state
       unknown_command
     end
   end
@@ -34,6 +33,7 @@ class MessengerService
       @user.update_attribute(:name, @input)
       send_message :ask_name_nice_to_meet, name: @input
       send_message :ask_name_getting_started
+      clear_state
     end
   end
 
@@ -42,8 +42,8 @@ class MessengerService
       card_set = QuizletService.find_card_set(@user, @input) # TODO handle failure case
       @user.current_card_set_id = card_set.id
       @user.save
-      clear_state
       send_message :select_quiz_success, title: card_set.title
+      clear_state
     else
       set_last_question 'give quizlet number'
       send_message :select_quiz_give_me_quizlet_number

--- a/app/services/quizlet_service.rb
+++ b/app/services/quizlet_service.rb
@@ -1,0 +1,25 @@
+class QuizletService
+
+  def self.find_card_set(user, quizlet_id)
+    set = CardSet.where(user_id: user.id, quizlet_id: quizlet_id).take
+    unless set.present?
+      set = CardSet.create(user_id: user.id, quizlet_id: quizlet_id)
+      populate_set(set, quizlet_id)
+    end
+    set
+  end
+
+  def self.populate_set(set, quizlet_id)
+    set_data = get_card_set(quizlet_id)
+    set.title = set_data['title']
+    set_data['terms'].each do |card|
+      Card.create(card_set_id: set.id, term: card['term'], definition: card['definition'])
+    end
+  end
+
+  def self.get_card_set(id)
+    response = RestClient.get "https://api.quizlet.com/2.0/sets/#{id}?client_id=#{ENV['QUIZLET_CLIENT_ID']}",
+                    accept: :json
+    JSON.parse(response)
+  end
+end

--- a/app/services/quizlet_service.rb
+++ b/app/services/quizlet_service.rb
@@ -19,7 +19,7 @@ class QuizletService
 
   def self.get_card_set(id)
     response = RestClient.get "https://api.quizlet.com/2.0/sets/#{id}?client_id=#{ENV['QUIZLET_CLIENT_ID']}",
-                    accept: :json
+                              accept: :json
     JSON.parse(response)
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,7 +33,11 @@ en:
   ask_name_getting_started: >
     Type 'register', 'study', or 'quiz me'
 
-  select_quiz_text: "You chose select quiz"
+  select_quiz_give_me_quizlet_number: >
+    Alright, go to Quizlets.com and give me the id of
+    a flashcard set you want to study.
+
+  select_quiz_success: "Ok I'm ready to help you study %{title}! Type 'study' or 'quiz me'"
 
   quiz_me_text: "You chose quiz me"
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,18 +31,36 @@ en:
     Nice to meet you %{name}! :D
 
   ask_name_getting_started: >
-    Type 'register', 'study', or 'quiz me'
+    Type 'select quiz' to choose a Quizlet set to start studying.
 
   select_quiz_give_me_quizlet_number: >
     Alright, go to Quizlets.com and give me the id of
+
     a flashcard set you want to study.
 
   select_quiz_success: "Ok I'm ready to help you study %{title}! Type 'study' or 'quiz me'"
 
+  study_getting_started: >
+    Ok, I'll message you one flashcard at a time. Type 'next' to move to the next one.
+    You can always choose 'register', or 'quiz me' to stop. Type 'next'.
+
+  study_choose_set_first: "Type 'select quiz' to choose a flashcard set to study"
+
+  study_flash_card: >
+    %{term}
+
+    ----------------
+
+    %{definition}
+
+
+  study_all_done: >
+    You've studied all %{count} cards! Nice job :D!
+    Type 'next' to start from the beginning or 'quiz me' if you're up for a challenge!
+
+
   quiz_me_text: "You chose quiz me"
 
-  study_text: "You chose study"
-
-  unknown_command: "Sorry I don't understand that. Type 'register', 'quiz me', or 'study'"
+  unknown_command: "Sorry I don't understand that. Type 'select quiz', 'quiz me', or 'study'"
 
 

--- a/db/migrate/20160916135105_create_users.rb
+++ b/db/migrate/20160916135105_create_users.rb
@@ -4,7 +4,8 @@ class CreateUsers < ActiveRecord::Migration[5.0]
       t.string :messenger_id
       t.string :name
       t.string :last_command
-      t.integer :last_question
+      t.string :last_question
+      t.string :current_card_set_id
 
       t.timestamps
     end

--- a/db/migrate/20160918200358_create_card_sets.rb
+++ b/db/migrate/20160918200358_create_card_sets.rb
@@ -1,0 +1,11 @@
+class CreateCardSets < ActiveRecord::Migration[5.0]
+  def change
+    create_table :card_sets do |t|
+      t.integer :user_id
+      t.string :quizlet_id
+      t.string :title
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20160918200507_create_cards.rb
+++ b/db/migrate/20160918200507_create_cards.rb
@@ -1,0 +1,13 @@
+class CreateCards < ActiveRecord::Migration[5.0]
+  def change
+    create_table :cards do |t|
+      t.integer :card_set_id
+      t.string :term
+      t.string :definition
+      t.integer :times_correct, default: 0
+      t.integer :times_tested, default: 0
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,15 +10,34 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160916135105) do
+ActiveRecord::Schema.define(version: 20160918200507) do
+
+  create_table "card_sets", force: :cascade do |t|
+    t.integer  "user_id"
+    t.string   "quizlet_id"
+    t.string   "title"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "cards", force: :cascade do |t|
+    t.integer  "card_set_id"
+    t.string   "term"
+    t.string   "definition"
+    t.integer  "times_correct", default: 0
+    t.integer  "times_tested",  default: 0
+    t.datetime "created_at",                null: false
+    t.datetime "updated_at",                null: false
+  end
 
   create_table "users", force: :cascade do |t|
     t.string   "messenger_id"
     t.string   "name"
     t.string   "last_command"
-    t.integer  "last_question"
-    t.datetime "created_at",    null: false
-    t.datetime "updated_at",    null: false
+    t.string   "last_question"
+    t.string   "current_card_set_id"
+    t.datetime "created_at",          null: false
+    t.datetime "updated_at",          null: false
   end
 
 end

--- a/test/fixtures/card_sets.yml
+++ b/test/fixtures/card_sets.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user_id: 1
+  quizlet_id: MyString
+  title: MyString
+
+two:
+  user_id: 1
+  quizlet_id: MyString
+  title: MyString

--- a/test/fixtures/cards.yml
+++ b/test/fixtures/cards.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  card_set_id: 1
+  term: MyString
+  definition: MyString
+
+two:
+  card_set_id: 1
+  term: MyString
+  definition: MyString

--- a/test/models/card_set_test.rb
+++ b/test/models/card_set_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class CardSetTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/card_test.rb
+++ b/test/models/card_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class CardTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Add support for the 'select quiz' and 'study' command.
- Added Gus' scaffoding of the card_set and card models. Also included some extra fields that I realized we'd need on the users model.
- Added structure to pull dialog from the `config/locales/en.yml` files. Please put all the long dialog flashy says in there and reference the key in the MessengerService.
- Filled out the QuizletService helper to fit into how it's being used.
- Added additonal dialog and routing to the MessengerService (for select quiz and study).
