### PR TITLE
Add support for the 'quiz me' command.

### DIFF
--- a/app/services/messenger_service.rb
+++ b/app/services/messenger_service.rb
@@ -14,6 +14,7 @@ class MessengerService
     return ask_name unless @user.name.present?
     command = @input.downcase.strip
     if COMMAND_TO_METHOD.key?(command)
+      clear_state
       @user.update_attribute(:last_command, command)
       self.send(COMMAND_TO_METHOD[command])
     elsif @user.last_command
@@ -134,7 +135,7 @@ class MessengerService
   end
 
   def quiz_me_check_correctness(card, comment)
-    if card.definition.lowercase.strip == @input.lowercase.strip
+    if card.definition.downcase.strip == @input.downcase.strip
       send_message :quiz_me_correct, comment: comment
     else
       send_message :quiz_me_incorrect, definition: card.definition, comment: comment

--- a/app/services/messenger_service.rb
+++ b/app/services/messenger_service.rb
@@ -90,7 +90,7 @@ class MessengerService
 
     if @user.last_question == '__start__'
       card = @user.current_card_set.cards.first
-      set_last_question '0'
+      save_last_question '0'
       return send_message :quiz_me_term, term: card.term
     end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -53,13 +53,26 @@ en:
 
     %{definition}
 
-
   study_all_done: >
     You've studied all %{count} cards! Nice job :D!
     Type 'next' to start from the beginning or 'quiz me' if you're up for a challenge!
 
+  quiz_me_getting_started: >
+    Ok, I'll message you one flashcard at a time. You tell me the definition.
+    Got it? Type 'start' to begin.
 
-  quiz_me_text: "You chose quiz me"
+  quiz_me_term: >
+    Term: %{term}
+
+  quiz_me_correct: >
+    Correct! Nice job :). %{comment}
+
+  quiz_me_incorrect: >
+    Sorry! That's wrong :(. The correct answer is %{definition}. %{comment}
+
+  quiz_me_all_done: >
+    You've studied all %{count} cards! Nice!!
+    Type 'next' to start over or 'study' to get some extra practice.
 
   unknown_command: "Sorry I don't understand that. Type 'select quiz', 'quiz me', or 'study'"
 


### PR DESCRIPTION
This add the functionality needed to allow flashy to quiz users when they type the 'quiz me' command.

There are 3 states for the command:
1. Initial state, the first card question has been sent.
2. Loop state. The input of the user is compared to the answer of the card that was last sent. Feedback about right or wrong is given, then the question to the next card is sent, setting that as the last sent card. This continues until the user reaches the last card in the card_set or until they type another root level command (`select quiz`, `study`, `quiz me`, etc).
3. End state. Only checks that last card sent's answer, then congratulates the user.
